### PR TITLE
Refactor SMTP transport to support anonymous mode

### DIFF
--- a/src/backend-express/services/txEmail.ts
+++ b/src/backend-express/services/txEmail.ts
@@ -412,7 +412,9 @@ async function getTransport(excludeHosts: string[] = []) {
     const errors: string[] = [];
     let firstTransport: TransportMeta | null = null;
 
-    const buildTransport = (cfg: (typeof candidates)[number]): TransportMeta => {
+    const buildTransport = (
+      cfg: (typeof candidates)[number],
+    ): TransportMeta => {
       if (!cfg.host) {
         throw new Error(`missing-host:${cfg.name}`);
       }
@@ -434,9 +436,13 @@ async function getTransport(excludeHosts: string[] = []) {
         options.auth = { user: cfg.user, pass: cfg.pass };
         mode = "authenticated";
       } else if (cfg.user || cfg.pass) {
-        logger.warn("Identifiants SMTP partiels, tentative en mode anonyme", "MAIL", {
-          name: cfg.name,
-        });
+        logger.warn(
+          "Identifiants SMTP partiels, tentative en mode anonyme",
+          "MAIL",
+          {
+            name: cfg.name,
+          },
+        );
       }
 
       return {

--- a/src/backend-express/services/txEmail.ts
+++ b/src/backend-express/services/txEmail.ts
@@ -403,7 +403,7 @@ async function getTransport(excludeHosts: string[] = []) {
     }
 
     type TransportMeta = {
-      transport: nodemailer.Transporter;
+      transport: Transporter;
       host: string;
       name: string;
       mode: "authenticated" | "anonymous";

--- a/src/backend-express/services/txEmail.ts
+++ b/src/backend-express/services/txEmail.ts
@@ -10,7 +10,7 @@ Performance: cache/partitionnement/bundling optimisés
 import { randomUUID } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import nodemailer from "nodemailer";
+import nodemailer, { type Transporter } from "nodemailer";
 import { logger } from "../utils/logger";
 import { normalizeEmail, partitionEmails } from "../utils/email";
 import type { Dao, DaoTask } from "@shared/dao";


### PR DESCRIPTION
## Changes Made

### SMTP Transport Refactoring
- **Restructured transport creation logic** in `getTransport()` function
- **Added `TransportMeta` type** to better structure transport metadata with fields:
  - `transport`: Transporter instance
  - `host`: SMTP host
  - `name`: Configuration name  
  - `mode`: Either "authenticated" or "anonymous"

### Anonymous SMTP Support
- **Implemented anonymous SMTP mode** when credentials are missing or incomplete
- **Added fallback logic** that allows SMTP without authentication when `user`/`pass` are empty
- **Enhanced logging** to include transport mode information
- **Added warning** when partial credentials are provided, falling back to anonymous mode

### Code Organization
- **Extracted `buildTransport()` helper function** to separate transport creation from verification
- **Improved error handling** with better error collection and reporting
- **Enhanced logging context** with additional metadata (host, name, mode)

### Testing
- **Added new test suite** for SMTP transport fallback scenarios
- **Added test case** for anonymous transport when credentials are absent
- **Mocked nodemailer** to verify anonymous mode configuration
- **Verified** that transport is created without auth when credentials are empty

### Import Changes
- **Added explicit type import** for `Transporter` from nodemailer

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cef23b1300fc46aea7a9bf0785697567/mystic-field)

👀 [Preview Link](https://cef23b1300fc46aea7a9bf0785697567-mystic-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cef23b1300fc46aea7a9bf0785697567</projectId>-->
<!--<branchName>mystic-field</branchName>-->